### PR TITLE
Add image imports to scripts.js

### DIFF
--- a/src/scripts.js
+++ b/src/scripts.js
@@ -4,6 +4,11 @@ import ingredientData from './data/ingredient-data';
 
 import './css/base.scss';
 import './css/styles.scss';
+import './images/apple-logo-outline.png';
+import './images/apple-logo.png';
+import './images/cookbook.png';
+import './images/seasoning.png';
+import './images/search.png';
 
 import User from './user';
 import Recipe from './recipe';


### PR DESCRIPTION
## Pull Request

<br>

### Description

* Is this a feature or a fix?
This is a fix

* Where should the reviewer start?
In the scripts.js file

* What functionalities do these changes effect? What was the motivation behind these changes?
Displays all icon images on the site - had to utilize import syntax to bring in the images via webpack. 

* What outside features or research did you use to implement this fix?
Webpack research

* How should this be tested?
Open the page in the browser

* Applicable screenshot(s): 
![Screen Shot 2021-01-05 at 5 56 08 PM](https://user-images.githubusercontent.com/69478485/103716075-65113700-4f7f-11eb-886a-2a9babb68816.png)

<br>

***

#### Please review considerations below:

- [x] Follows Turing Style Guidelines
- [x] Changes generate no new warnings or errors(linter etc)
- [ ] README has been updated(if applicable)
