### PR TITLE
Fix unfavorite to update instantly

### DIFF
--- a/src/scripts.js
+++ b/src/scripts.js
@@ -81,7 +81,7 @@ function createCards(recipeData) {
   });
 }
 
-function getIngredientNamesForRecipe () {
+function getIngredientNamesForRecipe() {
   recipes.forEach(recipe => {
     recipe.generateIngredientsNameById(ingredientsData);
     return recipe;
@@ -150,30 +150,19 @@ function filterRecipes(filtered) {
 }
 
 // FAVORITE RECIPE FUNCTIONALITY
-function addToMyRecipes() {
-  if (event.target.className === "card-apple-icon") {
+function addToMyRecipes(showSavedRecipes) {
+  if (event.target.className === "card-apple-icon" && document.querySelector(".my-recipes-banner").classList.contains("hidden")) {
     domUpdates.favoriteRecipe(user, event);
-  }
-  // if (event.target.className === "card-apple-icon") {
-  //   let cardId = parseInt(event.target.closest(".recipe-card").id)
-  //   if (!user.favoriteRecipes.includes(cardId)) {
-  //     event.target.src = "../images/apple-logo.png";
-  //     user.saveRecipe(cardId);
-  //   } else {
-  //     event.target.src = "../images/apple-logo-outline.png";
-  //     user.removeRecipe(cardId);
-  //   }
-  // }
-  else if (event.target.id === "exit-recipe-btn") {
+    removeUnfavoritedInstantly();
+  } else if (event.target.className === "card-apple-icon") {
+    domUpdates.favoriteRecipe(user, event);
+  } else if (event.target.id === "exit-recipe-btn") {
     exitRecipe();
   } else if (isDescendant(event.target.closest(".recipe-card"), event.target)) {
     openRecipeInfo(event);
   }
 }
 
-// function addToFavorites() {
-//   domUpdates.favoriteRecipe(user, event);
-// }
 
 function isDescendant(parent, child) {
   let node = child;
@@ -186,8 +175,21 @@ function isDescendant(parent, child) {
   return false;
 }
 
+function removeUnfavoritedInstantly() {
+  favoriteRecipes = recipes.filter(recipe => {
+    return user.favoriteRecipes.includes(recipe.id);
+  });
+  let unsavedRecipes = recipes.filter(recipe => {
+    return !user.favoriteRecipes.includes(recipe.id);
+  });
+  unsavedRecipes.forEach(recipe => {
+    let domRecipe = document.getElementById(`${recipe.id}`);
+    domRecipe.style.display = "none";
+  });
+}
+
 function showSavedRecipes() {
-    favoriteRecipes = recipes.filter(recipe => {
+  favoriteRecipes = recipes.filter(recipe => {
     return user.favoriteRecipes.includes(recipe.id);
   });
   let unsavedRecipes = recipes.filter(recipe => {
@@ -332,7 +334,10 @@ function findPantryInfo() {
     if (itemInfo && originalIngredient) {
       originalIngredient.count += item.amount;
     } else if (itemInfo) {
-      pantryInfo.push({name: itemInfo.name, count: item.amount});
+      pantryInfo.push({
+        name: itemInfo.name,
+        count: item.amount
+      });
     }
   });
   domUpdates.displayPantryInfo(pantryInfo.sort((a, b) => a.name.localeCompare(b.name)));

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -153,7 +153,7 @@ function filterRecipes(filtered) {
 function addToMyRecipes(showSavedRecipes) {
   if (event.target.className === "card-apple-icon" && document.querySelector(".my-recipes-banner").classList.contains("hidden")) {
     domUpdates.favoriteRecipe(user, event);
-    removeUnfavoritedInstantly();
+    filterFavorites();
   } else if (event.target.className === "card-apple-icon") {
     domUpdates.favoriteRecipe(user, event);
   } else if (event.target.id === "exit-recipe-btn") {
@@ -175,7 +175,7 @@ function isDescendant(parent, child) {
   return false;
 }
 
-function removeUnfavoritedInstantly() {
+function filterFavorites() {
   favoriteRecipes = recipes.filter(recipe => {
     return user.favoriteRecipes.includes(recipe.id);
   });
@@ -189,16 +189,7 @@ function removeUnfavoritedInstantly() {
 }
 
 function showSavedRecipes() {
-  favoriteRecipes = recipes.filter(recipe => {
-    return user.favoriteRecipes.includes(recipe.id);
-  });
-  let unsavedRecipes = recipes.filter(recipe => {
-    return !user.favoriteRecipes.includes(recipe.id);
-  });
-  unsavedRecipes.forEach(recipe => {
-    let domRecipe = document.getElementById(`${recipe.id}`);
-    domRecipe.style.display = "none";
-  });
+  filterFavorites()
   domUpdates.showMyRecipesBanner();
   liveSearch();
 }


### PR DESCRIPTION
## Pull Request

<br>

### Description

* Is this a feature or a fix?
Fix

* Where should the reviewer start?
scripts.js Line 178

* What functionalities do these changes effect? What was the motivation behind these changes?
When on the favorites screen, if you unfavorite a recipe it will instantly be removed from the screen. You now don't have to click the "My Recipes" button again to see the updated favorited recipes

* What outside features or research did you use to implement this fix?
Worked on top of the existing favoriting functions 

* How should this be tested?
Favorite a few recipes, click "My Recipes" then unfavorite one and it should disappear instantly. No errors should be shown in the console

* Applicable screenshot(s): 

<br>

***

#### Please review considerations below:

- [x] Follows Turing Style Guidelines
- [x] Changes generate no new warnings or errors(linter etc)
- [ ] README has been updated(if applicable)
