### PR TITLE
Feature collapsible aside

### DIFF
--- a/src/css/styles.scss
+++ b/src/css/styles.scss
@@ -55,6 +55,7 @@ aside {
   background-color: $white;
   @include flex(column);
   justify-content: flex-start;
+  min-height: 100vh;
 }
 
 .wrap {
@@ -69,7 +70,7 @@ aside {
 ul {
   list-style-type: none;
   text-align: left;
-  padding-left: 35px;
+  padding-left: 27px;
 
   li {
     margin: 2px;
@@ -77,7 +78,7 @@ ul {
 }
 
 .pantry-drop-down,
-.type-drop-down {
+.tag-drop-down {
   max-height: 0.8em;
   max-width: 1em;
 }
@@ -103,29 +104,29 @@ ul {
 }
 
 /* PANTRY LIST */
-.drop-menu {
-  @include dimensions(600px, 250px);
-  align-items: center;
-  background-color: $white;
-  display: none;
-  margin-left: 81%;
-  margin-top: 92px;
-  overflow: scroll;
-  padding: 12px ;
-  position: absolute;
-  text-align: center;
-  z-index: 3;
-
-  h2 {
-    color: $dark-green;
-    margin: 0px;
-
-  .pantry-list {
-    padding-left: 15px;
-    text-align: left;
-  }
-  }
-}
+// .drop-menu {
+//   @include dimensions(600px, 250px);
+//   align-items: center;
+//   background-color: $white;
+//   display: none;
+//   margin-left: 81%;
+//   margin-top: 92px;
+//   overflow: scroll;
+//   padding: 12px ;
+//   position: absolute;
+//   text-align: center;
+//   z-index: 3;
+//
+//   h2 {
+//     color: $dark-green;
+//     margin: 0px;
+//
+//   .pantry-list {
+//     padding-left: 15px;
+//     text-align: left;
+//   }
+//   }
+// }
 
 .hidden {
   display: none;

--- a/src/css/styles.scss
+++ b/src/css/styles.scss
@@ -76,7 +76,8 @@ ul {
   }
 }
 
-.right-arrow {
+.pantry-drop-down,
+.type-drop-down {
   max-height: 0.8em;
   max-width: 1em;
 }

--- a/src/css/styles.scss
+++ b/src/css/styles.scss
@@ -76,6 +76,11 @@ ul {
   }
 }
 
+.right-arrow {
+  max-height: 0.8em;
+  max-width: 1em;
+}
+
 /* BUTTONS */
 .square-btns {
   @include dimensions(40px, 200px);
@@ -119,4 +124,8 @@ ul {
     text-align: left;
   }
   }
+}
+
+.hidden {
+  display: none;
 }

--- a/src/domUpdates.js
+++ b/src/domUpdates.js
@@ -168,10 +168,12 @@ let domUpdates = {
     let cardId = parseInt(event.target.closest(".recipe-card").id);
     if (!user.favoriteRecipes.includes(cardId)) {
       event.target.src = "../images/apple-logo.png";
-      user.saveRecipe(cardId, "favoriteRecipes");
+      event.target.alt ="filled apple icon";
+      user.saveRecipe(cardId);
     } else {
       event.target.src = "../images/apple-logo-outline.png";
-      user.removeRecipe(cardId, "favoriteRecipes");
+      event.target.alt ="unfilled apple icon";
+      user.removeRecipe(cardId);
     }
   },
 
@@ -180,10 +182,12 @@ let domUpdates = {
     let cardId = parseInt(event.target.closest(".recipe-card").id)
     if (!user.recipesToCook.includes(cardId)) {
       event.target.src = "../images/full-pot.png";
+      event.target.alt ="filled pot icon";
       user.saveRecipe(cardId, "recipesToCook");
     } else {
       event.target.src = "../images/pot-outline.png";
-      user.removeRecipe(cardId, "recipesToCook");
+      event.target.alt ="unfilled pot icon";
+      user.removeRecipe(cardId, "");
     }
   },
 

--- a/src/domUpdates.js
+++ b/src/domUpdates.js
@@ -168,11 +168,11 @@ let domUpdates = {
     if (!user.favoriteRecipes.includes(cardId)) {
       event.target.src = "../images/apple-logo.png";
       event.target.alt ="filled apple icon";
-      user.saveRecipe(cardId);
+      user.saveRecipe(cardId, "favoriteRecipes");
     } else {
       event.target.src = "../images/apple-logo-outline.png";
       event.target.alt ="unfilled apple icon";
-      user.removeRecipe(cardId);
+      user.removeRecipe(cardId, "favoriteRecipes");
     }
   },
 

--- a/src/domUpdates.js
+++ b/src/domUpdates.js
@@ -187,7 +187,7 @@ let domUpdates = {
     } else {
       event.target.src = "../images/pot-outline.png";
       event.target.alt ="unfilled pot icon";
-      user.removeRecipe(cardId, "");
+      user.removeRecipe(cardId, "recipesToCook");
     }
   },
 

--- a/src/domUpdates.js
+++ b/src/domUpdates.js
@@ -34,8 +34,7 @@ let domUpdates = {
   },
 
   // FILTER BY RECIPE TAGS
-  listRecipeTagsOnDom(allTags) {
-    let tagList = document.querySelector(".tag-list");
+  listRecipeTagsOnDom(allTags, tagList) {
     allTags.forEach(tag => {
       let tagHtml = `<li><input type="checkbox" class="checked-tag" id="${tag}">
       <label for="${tag}">${capitalize(tag)}</label></li>`;

--- a/src/index.html
+++ b/src/index.html
@@ -20,23 +20,23 @@
       <button tabindex="3" class="nav-btn meals-to-cook-btn connect" type="button" name="button"><img class="connect" src="../images/seasoning.png" alt="my meals to cook button">Meals To Cook</button>
     </header>
     <section class="banner-image">
-      <div class="my-recipes-banner">
+      <div class="my-recipes-banner hidden">
         <h1>My Recipes</h1>
         <button class="back-to-main-btn square-btns">Show All Recipes</button>
       </div>
-      <div class="my-meals-to-cook-banner">
+      <div class="my-meals-to-cook-banner hidden">
         <h1>My Meals To Cook</h1>
         <button class="show-all-btn square-btns">Show All Recipes</button>
       </div>
     </section>
     <aside>
       <div class="wrap">
-        <h2><img tabindex="4" class="right-arrow" src="../images/right-arrow.png" alt="menu collapsed" /> My Pantry</h2>
+        <h2><img tabindex="4" class="pantry-drop-down" src="../images/right-arrow.png" alt="menu collapsed" /> My Pantry</h2>
         <ul class="pantry-tag-list hidden">
         </ul>
       </div>
       <div class="wrap">
-        <h2><img tabindex="5" class="right-arrow" src="../images/right-arrow.png" alt="menu collapsed" /> Recipe Type</h2>
+        <h2><img tabindex="5" class="type-drop-down" src="../images/right-arrow.png" alt="menu collapsed" /> Recipe Type</h2>
         <ul class="tag-list hidden">
         </ul>
         <button class="filter-btn square-btns">Filter Recipes</button>

--- a/src/index.html
+++ b/src/index.html
@@ -29,21 +29,15 @@
         <button class="show-all-btn square-btns">Show All Recipes</button>
       </div>
     </section>
-    <!-- <div class="drop-menu">
-      <h2>My Pantry</h2>
-      <button class="show-pantry-recipes-btn square-btns">What Can I Make?</button>
-      <ul class="pantry-list"></ul>
-    </div> -->
     <aside>
       <div class="wrap">
-        <h2>My Pantry</h2>
-        <ul class="pantry-tag-list">
+        <h2><img tabindex="4" class="right-arrow" src="../images/right-arrow.png" alt="menu collapsed" /> My Pantry</h2>
+        <ul class="pantry-tag-list hidden">
         </ul>
-        <button class="filter-btn square-btns">Show My Pantry</button>
       </div>
       <div class="wrap">
-        <h2>Recipe Type</h2>
-        <ul class="tag-list">
+        <h2><img tabindex="5" class="right-arrow" src="../images/right-arrow.png" alt="menu collapsed" /> Recipe Type</h2>
+        <ul class="tag-list hidden">
         </ul>
         <button class="filter-btn square-btns">Filter Recipes</button>
       </div>

--- a/src/index.html
+++ b/src/index.html
@@ -20,11 +20,11 @@
       <button tabindex="3" class="nav-btn meals-to-cook-btn connect" type="button" name="button"><img class="connect" src="../images/seasoning.png" alt="my meals to cook button">Meals To Cook</button>
     </header>
     <section class="banner-image">
-      <div class="my-recipes-banner hidden">
+      <div class="my-recipes-banner">
         <h1>My Recipes</h1>
         <button class="back-to-main-btn square-btns">Show All Recipes</button>
       </div>
-      <div class="my-meals-to-cook-banner hidden">
+      <div class="my-meals-to-cook-banner">
         <h1>My Meals To Cook</h1>
         <button class="show-all-btn square-btns">Show All Recipes</button>
       </div>

--- a/src/index.html
+++ b/src/index.html
@@ -36,7 +36,7 @@
         </ul>
       </div>
       <div class="wrap">
-        <h2><img tabindex="5" class="type-drop-down" src="../images/right-arrow.png" alt="menu collapsed" /> Recipe Type</h2>
+        <h2><img tabindex="5" class="tag-drop-down" src="../images/right-arrow.png" alt="menu collapsed" /> Recipe Type</h2>
         <ul class="tag-list hidden">
         </ul>
         <button class="filter-btn square-btns">Filter Recipes</button>

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -25,9 +25,12 @@ let filterBtn = document.querySelector(".filter-btn");
 let fullRecipeInfo = document.querySelector(".recipe-instructions");
 let main = document.querySelector("main");
 let mealsToCookBtn = document.querySelector(".meals-to-cook-btn");
+let pantryDropDown = document.querySelector(".pantry-drop-down");
+let pantryList = document.querySelector(".pantry-tag-list")
 let savedRecipesBtn = document.querySelector(".saved-recipes-btn");
 let searchForm = document.querySelector("#search");
 let searchInput = document.querySelector("#search-input");
+let typeDropDown = document.querySelector(".type-drop-down");
 
 //GLOBAL VARIABLES
 let user;
@@ -45,6 +48,7 @@ filterBtn.addEventListener("click", findCheckedBoxes);
 main.addEventListener("click", addToMyRecipes);
 main.addEventListener("keyup", pressEnterToViewInfoOrFavorite)
 mealsToCookBtn.addEventListener("click", showMealsToCook);
+pantryDropDown.addEventListener("click", toggleDropDown);
 savedRecipesBtn.addEventListener("click", showSavedRecipes);
 searchForm.addEventListener("keyup", liveSearch);
 
@@ -141,7 +145,7 @@ function filterRecipes(filtered) {
 }
 
 // FAVORITE RECIPE FUNCTIONALITY
-function pressEnterToViewInfoOrFavorite(event){
+function pressEnterToViewInfoOrFavorite(event) {
   if (event.keyCode === 13) {
     addToMyRecipes();
   }
@@ -234,7 +238,7 @@ function exitRecipe() {
 function liveSearch() {
   if (document.querySelector(".my-recipes-banner").classList.contains("hidden")) {
     searchRecipes(user.generateRecipeInfoByID(recipeData, "favoriteRecipes"));
-  } else if (document.querySelector(".my-meals-to-cook-banner").classList.contains("hidden")){
+  } else if (document.querySelector(".my-meals-to-cook-banner").classList.contains("hidden")) {
     searchRecipes(user.generateRecipeInfoByID(recipeData, "recipesToCook"));
 
   } else {
@@ -311,4 +315,16 @@ function findRecipesWithCheckedIngredients(selected) {
       domRecipe.style.display = "none";
     }
   })
+}
+
+
+// TOGGLE DROP DOWN MENU
+function toggleDropDown() {
+  if (event.target.className.includes("pantry-drop-down") && pantryList.className.includes("hidden")) {
+    pantryList.classList.remove("hidden");
+    pantryDropDown.src ="../images/down-arrow.png";
+  } else if (event.target.className.includes("pantry-drop-down") && !pantryList.className.includes("hidden")){
+    pantryList.classList.add("hidden");
+    pantryDropDown.src ="../images/right-arrow.png";
+  }
 }

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -9,8 +9,10 @@ import domUpdates from './domUpdates.js';
 import './images/apple-logo-outline.png';
 import './images/apple-logo.png';
 import './images/cookbook.png';
+import './images/down-arrow.png';
 import './images/full-pot.png';
 import './images/pot-outline.png';
+import './images/right-arrow.png';
 import './images/seasoning.png';
 import './images/search.png';
 //CLASSES

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -30,6 +30,7 @@ let pantryList = document.querySelector(".pantry-tag-list")
 let savedRecipesBtn = document.querySelector(".saved-recipes-btn");
 let searchForm = document.querySelector("#search");
 let searchInput = document.querySelector("#search-input");
+let tagList = document.querySelector(".tag-list");
 let typeDropDown = document.querySelector(".type-drop-down");
 
 //GLOBAL VARIABLES
@@ -51,6 +52,7 @@ mealsToCookBtn.addEventListener("click", showMealsToCook);
 pantryDropDown.addEventListener("click", toggleDropDown);
 savedRecipesBtn.addEventListener("click", showSavedRecipes);
 searchForm.addEventListener("keyup", liveSearch);
+typeDropDown.addEventListener("click", toggleDropDown);
 
 //Generate API Data on Load
 function fetchAllData() {
@@ -107,7 +109,7 @@ function findTags(recipeData) {
     });
   });
   tags.sort();
-  domUpdates.listRecipeTagsOnDom(tags);
+  domUpdates.listRecipeTagsOnDom(tags, tagList);
 }
 
 function findCheckedBoxes() {
@@ -325,6 +327,12 @@ function toggleDropDown() {
     pantryDropDown.src ="../images/down-arrow.png";
   } else if (event.target.className.includes("pantry-drop-down") && !pantryList.className.includes("hidden")){
     pantryList.classList.add("hidden");
-    pantryDropDown.src ="../images/right-arrow.png";
+    pantryDropDown.src="../images/right-arrow.png";
+  } else if (event.target.className.includes("type-drop-down") && tagList.className.includes("hidden")) {
+    tagList.classList.remove("hidden");
+    typeDropDown.src="../images/down-arrow.png";
+  } else if (event.target.className.includes("type-drop-down") && !tagList.className.includes("hidden")){
+    tagList.classList.add("hidden");
+    typeDropDown.src="../images/right-arrow.png";
   }
 }

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -31,7 +31,7 @@ let savedRecipesBtn = document.querySelector(".saved-recipes-btn");
 let searchForm = document.querySelector("#search");
 let searchInput = document.querySelector("#search-input");
 let tagList = document.querySelector(".tag-list");
-let typeDropDown = document.querySelector(".type-drop-down");
+let tagDropDown = document.querySelector(".tag-drop-down");
 
 //GLOBAL VARIABLES
 let user;
@@ -52,7 +52,7 @@ mealsToCookBtn.addEventListener("click", showMealsToCook);
 pantryDropDown.addEventListener("click", toggleDropDown);
 savedRecipesBtn.addEventListener("click", showSavedRecipes);
 searchForm.addEventListener("keyup", liveSearch);
-typeDropDown.addEventListener("click", toggleDropDown);
+tagDropDown.addEventListener("click", toggleDropDown);
 
 //Generate API Data on Load
 function fetchAllData() {
@@ -323,16 +323,17 @@ function findRecipesWithCheckedIngredients(selected) {
 // TOGGLE DROP DOWN MENU
 function toggleDropDown() {
   if (event.target.className.includes("pantry-drop-down") && pantryList.className.includes("hidden")) {
-    pantryList.classList.remove("hidden");
-    pantryDropDown.src ="../images/down-arrow.png";
+    toggleHiddenAndArrowDirection(pantryList, pantryDropDown, "remove", "down")
   } else if (event.target.className.includes("pantry-drop-down") && !pantryList.className.includes("hidden")){
-    pantryList.classList.add("hidden");
-    pantryDropDown.src="../images/right-arrow.png";
-  } else if (event.target.className.includes("type-drop-down") && tagList.className.includes("hidden")) {
-    tagList.classList.remove("hidden");
-    typeDropDown.src="../images/down-arrow.png";
-  } else if (event.target.className.includes("type-drop-down") && !tagList.className.includes("hidden")){
-    tagList.classList.add("hidden");
-    typeDropDown.src="../images/right-arrow.png";
+    toggleHiddenAndArrowDirection(pantryList, pantryDropDown, "add", "right")
+  } else if (event.target.className.includes("tag-drop-down") && tagList.className.includes("hidden")) {
+    toggleHiddenAndArrowDirection(tagList, tagDropDown, "remove", "down")
+  } else if (event.target.className.includes("tag-drop-down") && !tagList.className.includes("hidden")){
+    toggleHiddenAndArrowDirection(tagList, tagDropDown, "add", "right")
   }
+}
+
+function toggleHiddenAndArrowDirection(list, dropDown, addOrRemove, direction){
+  list.classList[addOrRemove]("hidden");
+  dropDown.src =`../images/${direction}-arrow.png`;
 }


### PR DESCRIPTION
## Pull Request

<br>

### Description

* Is this a feature or a fix?
Feature

* Where should the reviewer start?
scripts.js line 321

* What functionalities do these changes effect? What was the motivation behind these changes?
This makes it so that on load the aside that contains the checkboxes for the pantry and recipe types are collapse. You can now click the green right arrow and the list will drop down and display. To get it to return to collapsed you can press the now green down arrow and it will be hidden again. 

* What outside features or research did you use to implement this fix?
None

* How should this be tested?
The arrows should point right on load, then down once clicked and the list be shown, then right again when clicked and list hidden again. 

* Applicable screenshot(s): 

<br>

***

#### Please review considerations below:

- [x] Follows Turing Style Guidelines
- [x] Changes generate no new warnings or errors(linter etc)
- [ ] README has been updated(if applicable)
